### PR TITLE
Copying result with ProxyResultSetMethod on it results in failure

### DIFF
--- a/t/row/proxy-resultset-method.t
+++ b/t/row/proxy-resultset-method.t
@@ -30,5 +30,11 @@ subtest 'loaded data' => sub {
    is($g2->id_plus_two, 4, 'slot and specified method');
 };
 
+subtest 'copy result' => sub {
+    ok my $g3 = $g2->copy({ id => 3 }), 'Copied result.';
+    isa_ok $g3, 'DBIx::Class::Row';
+    is $g3->id, 3, 'ID = 3';
+};
+
 done_testing;
 


### PR DESCRIPTION
Copy fails with

```
DBIx::Class::ResultSource::columns_info(): No such column 'id_plus_one' on source 'Gnarly'
```

[15:12:55] <moltar>  frew: when trying to ->copy a $result which has ::ProxyResultSetMethod on it, it stuffs the data into _column_data and when trying to copy it fails with No such column 'archive_count' on source ...
[15:13:16] @frew   ah I bet it does
[15:13:25] @frew   moltar: get me a test and I'll take care of it
[15:13:29] @frew   otherwise it might be a day or two
[15:13:42] <moltar>  ok lets see what i can do :)
[15:13:56] @frew   hmmm
[15:14:13] @frew   I bet even w/e ProxyResultSetMethod it can still happen if you prefetch
[15:14:36] @frew   though ofc ProxyResultSetMethod could fix it.
