### PR TITLE
Doc tweaks on subclassing with Candy

### DIFF
--- a/lib/DBIx/Class/Helper/Row/SubClass.pm
+++ b/lib/DBIx/Class/Helper/Row/SubClass.pm
@@ -55,7 +55,7 @@ sub set_table {
 
  use parent 'DBIx::Class';
 
- __PACKAGE__->load_components('Core');
+ __PACKAGE__->load_components(qw{Helper::Row::SubClass Core});
 
  __PACKAGE__->table('Bar');
 
@@ -73,8 +73,6 @@ sub set_table {
 
  use parent 'ParentSchema::Result::Bar';
 
- __PACKAGE__->load_components(qw{Helper::Row::SubClass Core});
-
  __PACKAGE__->subclass;
 
 or with L<DBIx::Class::Candy>:
@@ -82,7 +80,8 @@ or with L<DBIx::Class::Candy>:
  # define parent class
  package ParentSchema::Result::Bar;
 
- use DBIx::Class::Candy;
+ use DBIx::Class::Candy
+    -components => ['Helper::Row::SubClass'];
 
  table 'Bar'; # or use -autotable => v1, but see below
 
@@ -95,8 +94,7 @@ or with L<DBIx::Class::Candy>:
  package MySchema::Result::Bar;
 
  use DBIx::Class::Candy
-    -base => 'ParentSchema::Result::Bar',
-    -components => ['Helper::Row::SubClass'];
+    -base => 'ParentSchema::Result::Bar';
 
  subclass;
 
@@ -104,10 +102,13 @@ or with L<DBIx::Class::Candy>:
 
 This component is to allow simple subclassing of L<DBIx::Class> Result classes.
 
+You can load the C<::Helper::Row::Subclass> component in your parent class or
+your child classes individually.
+
 B<NB:> if your parent class is defined above the C<::Result> level (and
-therefore won't have a table deployed for it by default) you still need to set
+therefore won't have a table deployed for it by default), you still need to set
 the table.  (Any value such as 'Dummy' will do.  L<DBIx::Class::Candy>'s
-C<autotable> functionality won't work in this case, so you should omit that and 
+C<autotable> functionality won't work in this case, so you should omit that and
 set the C<table> manually.)
 
 =head1 METHODS


### PR DESCRIPTION
(As I was a bit confused about whether this was possible, as the docs didn't mention this case.)

I've also added a note about the requirement to explicitly call 'table' in Candy -- that isn't needed if your parent class is _also_ a bona fide result (but it isn't in my case).

Finally, in 2nd commit, I've noted that you can load the component in parent.  This makes more sense to me, but let me know if that's a Really Bad Idea :-)
