### PR TITLE
Make sure _proxy_slots is not undef.

### DIFF
--- a/lib/DBIx/Class/Helper/Row/ProxyResultSetMethod.pm
+++ b/lib/DBIx/Class/Helper/Row/ProxyResultSetMethod.pm
@@ -40,7 +40,7 @@ sub proxy_resultset_method {
 }
 
 sub copy {
-   delete local @{$_[0]->{_column_data}}{@{$_[0]->_proxy_slots||{}}};
+   delete local @{$_[0]->{_column_data}}{@{$_[0]->_proxy_slots||[]}};
 
    shift->next::method(@_);
 }

--- a/t/lib/TestSchema/Result/Bloaty.pm
+++ b/t/lib/TestSchema/Result/Bloaty.pm
@@ -1,7 +1,8 @@
 package TestSchema::Result::Bloaty;
 
 use DBIx::Class::Candy -components => [
-   'Helper::Row::ProxyResultSetUpdate'
+   'Helper::Row::ProxyResultSetUpdate',
+   'Helper::Row::ProxyResultSetMethod',
 ];
 
 table 'Bloaty';

--- a/t/row/proxy-resultset-method.t
+++ b/t/row/proxy-resultset-method.t
@@ -38,5 +38,11 @@ subtest 'copy result' => sub {
     is $g3->id, 100, 'id is correctly overridden';
 };
 
+subtest 'copy result without any proxy defined' => sub {
+   my $bloaty = $schema->resultset('Bloaty')->first;
+   ok my $bcopy = $bloaty->copy({ id => 100, name => 'boo' }), 'Copied result';
+   is $bcopy->id, 100, 'id is correctly overridden';
+};
+
 done_testing;
 


### PR DESCRIPTION
This condition can happen when no correlated methods defined, but the component is loaded anyways in the base class. Then when you copy, `_proxy_slots` is `undef` and results in an error.
