### PR TITLE
Increase test coverage (ha!)

### DIFF
--- a/t/Row/RelationshipDWIM.t
+++ b/t/Row/RelationshipDWIM.t
@@ -15,6 +15,8 @@ my $r = $schema->resultset('Bar')->result_class;
 
 ok $r->has_relationship('foo'), 'has Foo';
 ok $r->has_relationship('foos'), 'has foos';
+ok $r->has_relationship('might_have_foo'), 'might have Foo';
+ok $r->has_relationship('has_one_foo'), 'has one Foo';
 
 done_testing;
 

--- a/t/Row/StorageValues.t
+++ b/t/Row/StorageValues.t
@@ -21,4 +21,16 @@ is($first->get_storage_value('foo_id'), 1, 'foo_id storage value is still 1');
 $first->update;
 is($first->get_storage_value('foo_id'), 2, 'foo_id storage value is updated to 2');
 
+my $new = $schema->resultset('Bar')->new({
+   id => 999,
+   foo_id => 1,
+});
+is($new->foo_id, 1, 'new row of course has set values');
+is($new->get_storage_value('foo_id'), 1, 'and storage values are set');
+$new->foo_id(2);
+is($new->foo_id, 2, 'updated row has new value');
+is($new->get_storage_value('foo_id'), 1, 'but storage values are unchanged');
+$new->insert;
+is($new->get_storage_value('foo_id'), 2, 'storage value updated after insert');
+
 done_testing;

--- a/t/lib/ParentSchema/Result/Bar.pm
+++ b/t/lib/ParentSchema/Result/Bar.pm
@@ -23,5 +23,7 @@ primary_key 'id';
 
 belongs_to foo => '::Foo', 'foo_id';
 has_many  foos => '::Foo', 'bar_id';
+might_have might_have_foo => '::Foo', 'bar_id';
+has_one has_one_foo => '::Foo', 'bar_id';
 
 1;

--- a/t/lib/VerifySchema.pm
+++ b/t/lib/VerifySchema.pm
@@ -25,6 +25,10 @@ __PACKAGE__->load_components(qw(
    Helper::Schema::Verifier
 ));
 
+# so ::Verifier::load_classes gets tested too
+__PACKAGE__->load_classes({
+   ParentSchema => [qw/ Result::Foo Result::Bar /],
+});
 __PACKAGE__->load_namespaces;
 
 'zomg';

--- a/t/lib/VerifySchema.pm
+++ b/t/lib/VerifySchema.pm
@@ -23,6 +23,7 @@ sub result_verifiers {
 
 __PACKAGE__->load_components(qw(
    Helper::Schema::Verifier
+   Helper::Schema::Verifier::Parent
 ));
 
 # so ::Verifier::load_classes gets tested too


### PR DESCRIPTION
Check out e9302abfbf96506d81b7a422f32591d6a433c57c specifically, I think it shows a strange situation with Row::StorageValues. What should the storage values be on a new row before it's even hit storage? I made tests for the existing behaviour, but I think it should really show undef until it's inserted.