### PR TITLE
Stop leaking an isa() into the inheritance chain

### DIFF
--- a/t/lib/A/ResultSet/DateMethods1.pm
+++ b/t/lib/A/ResultSet/DateMethods1.pm
@@ -1,7 +1,7 @@
 package A::ResultSet::DateMethods1;
 
 use Test::Roo;
-use Test::Deep;
+use Test::Deep 'cmp_deeply';
 use DateTime;
 use Test::Fatal;
 


### PR DESCRIPTION
As per https://metacpan.org/pod/Test::Deep#isa-class-Isa-class `isa()` 
is a default export (wtf?!). While it doesn't seem to cause issues,
specific 5.8 configurations issue 'redefined' warnings due to this.

Using namespace::clean won't cut it due to how things interact in the
stack, but the proposed change passes tests just fine here.