### PR TITLE
Relationships JSON

### DIFF
--- a/lib/DBIx/Class/Helper/Row/ToJSON.pm
+++ b/lib/DBIx/Class/Helper/Row/ToJSON.pm
@@ -50,7 +50,7 @@ sub TO_JSON {
    my $columns_info = $self->columns_info($self->serializable_columns);
 
    return {
-      map +($_ => $self->$_),
+      map {my $col=$_;$_ => UNIVERSAL::can($self->$_,'columns')?{map +(%{UNIVERSAL::can($self->$col->$_,'TO_JSON')?$self->$col->$_->TO_JSON:{$_,$self->$col->$_}}),$self->$_->columns}:$self->$_}
       map +($columns_info->{$_}{accessor} || $_),
           keys %$columns_info
    };

--- a/t/Row/ToJSON.t
+++ b/t/Row/ToJSON.t
@@ -77,4 +77,16 @@ ACCESSOR_CLASS: {
    }], 'accessor fields with TO_JSON works');
 }
 
+RELATIONSHIPS_JSON: {
+	my $data = $schema->resultset('Foo2Bar')->find({foo_id=>2})->TO_JSON();
+	cmp_deeply($data,{
+		'test_flag' => undef,
+		'id' => 2,
+		'foo_id' => {
+                	'bar_id' => 2,
+			'id' => 2
+		}
+	},'Belongs 2 fields JSON');
+}
+
 done_testing;

--- a/t/lib/TestSchema/Result/Foo2Bar.pm
+++ b/t/lib/TestSchema/Result/Foo2Bar.pm
@@ -1,0 +1,19 @@
+package TestSchema::Result::Foo2Bar;
+
+use DBIx::Class::Candy
+   -base => 'ParentSchema::Result::Bar',
+   -components => [qw(
+      Helper::Row::ToJSON
+      Helper::Row::SubClass
+      Helper::Row::OnColumnChange
+      Helper::Row::SelfResultSet
+      Helper::Row::CleanResultSet
+    )];
+
+__PACKAGE__->mk_group_accessors(inherited => 'on_column_change_allow_override_args');
+our @events;
+
+subclass;
+
+__PACKAGE__->belongs_to('foo_id','TestSchema::Result::Foo','id');
+1;


### PR DESCRIPTION
When we use relationships - your TO_JSON won't process it.
For example: if table 'users' and 'plans' with relationship user.plan -> plan.id then, when we do $user->TO_JSON we'll receive this: {"user_id":1,"plan":MyAPP::Result::Plan=HASH(0x00000000)}
With this patch result will be like this:
{"user_id":1,"plan":{"id":1,"name":"wow"}}
