### PR TITLE
Return prefetched result when available

### DIFF
--- a/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
@@ -7,7 +7,14 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
-sub one_row { shift->search(undef, { rows => 1})->next }
+sub one_row {
+  my ($self) = @_;
+  if (my $cache = $self->get_cache) {
+    return $cache->[0];
+  } else {
+    return $self->search(undef, { rows => 1})->next;
+  }
+}
 
 1;
 


### PR DESCRIPTION
Here's the commit we discussed to allow ->one_row to return the row from prefetched data when possible.