### PR TITLE
Add method unserializable_data_types to ToJSON helper

### DIFF
--- a/lib/DBIx/Class/Helper/Row/ToJSON.pm
+++ b/lib/DBIx/Class/Helper/Row/ToJSON.pm
@@ -8,6 +8,7 @@ use warnings;
 use parent 'DBIx::Class::Row';
 
 __PACKAGE__->mk_group_accessors(inherited => '_serializable_columns');
+__PACKAGE__->mk_group_accessors(inherited => '_unserializable_data_types');
 
 my $dont_serialize = {
    text  => 1,
@@ -22,7 +23,7 @@ sub _is_column_serializable {
 
    if (!defined $info->{is_serializable}) {
       if (defined $info->{data_type} &&
-          $dont_serialize->{lc $info->{data_type}}
+          $self->unserializable_data_types->{lc $info->{data_type}}
       ) {
          $info->{is_serializable} = 0;
       } else {
@@ -54,6 +55,14 @@ sub TO_JSON {
       map +($columns_info->{$_}{accessor} || $_),
           keys %$columns_info
    };
+}
+
+sub unserializable_data_types {
+   my $self = shift;
+   if (!$self->_unserializable_data_types) {
+      $self->_unserializable_data_types($dont_serialize);
+   }
+   return $self->_unserializable_data_types;
 }
 
 1;
@@ -139,4 +148,21 @@ to the returned hashref:
        customer_name => $self->customer->name,
        %{ $self->next::method },
     }
+ }
+
+=method unserializable_data_types
+
+ $self->unserializable_data_types
+
+Simply returns a hashref of data types that TO_JSON should not serialize.
+Defaults to C<blob>, C<text>, or C<ntext>.
+
+If you wanted to allow serialization of text data types, you might override this
+method to look like this:
+
+ sub unserializable_data_types {
+    return {
+       blob  => 1,
+       ntext => 1,
+    };
  }

--- a/t/Row/ToJSON.t
+++ b/t/Row/ToJSON.t
@@ -77,4 +77,22 @@ ACCESSOR_CLASS: {
    }], 'accessor fields with TO_JSON works');
 }
 
+SERIALIZE_ALL_DATA_TYPES: {
+   my $datas = [
+      map $_->TO_JSON,
+         $schema->resultset('SerializeAll')->search(undef, { order_by => 'id' })->all
+      ];
+
+   cmp_deeply($datas, [{
+         id => 1,
+         text_column => 'frew',
+      },{
+         id => 2,
+         text_column => 'frioux',
+      },{
+         id => 3,
+         text_column => 'frooh',
+   }], 'serialize all data types with TO_JSON');
+}
+
 done_testing;

--- a/t/lib/TestSchema.pm
+++ b/t/lib/TestSchema.pm
@@ -123,6 +123,13 @@ sub prepopulate {
       [2,'cc','dd'],
       [3,'ee','ff'],
    ]);
+
+   $self->populate(SerializeAll => [
+      [qw{id text_column}],
+      [1,'frew'],
+      [2,'frioux'],
+      [3,'frooh'],
+   ]);
 }
 
 'kitten eater';

--- a/t/lib/TestSchema/Result/SerializeAll.pm
+++ b/t/lib/TestSchema/Result/SerializeAll.pm
@@ -1,0 +1,15 @@
+package TestSchema::Result::SerializeAll;
+
+use DBIx::Class::Candy
+   -components => [qw(
+      Helper::Row::ToJSON
+   )];
+
+table 'SerializeAll';
+
+primary_column id => { data_type => 'int' };;
+column text_column => { data_type => 'text' };
+
+sub unserializable_data_types { {} }
+
+1;


### PR DESCRIPTION
On some databases, columns with the text data type might want to be serialized. The ToJSON helper defaults prevented this, so it needed to be subclassed as well as some of the code duplicated. Adding the new method unserializable_data_types simplifies overriding the defaults.

Fixes #79