### PR TITLE
enable tests against SQLite on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_install:
    - export DBIITEST_PG_DSN='dbi:Pg:database=dbii_test;host=127.0.0.1'
    - export DBIITEST_PG_USER=postgres
 
+   - export DBIITEST_SQLITE_DSN='dbi:SQLite::memory:'
+
    - /bin/sync
 
 install:

--- a/t/ResultSet/DateMethods1/sqlite.t
+++ b/t/ResultSet/DateMethods1/sqlite.t
@@ -14,9 +14,6 @@ A::ResultSet::DateMethods1->run_tests(SQLite => {
    plucked_minute => '09',
    plucked_second => '08',
 
-   connect_info => [ 'dbi:SQLite::memory:' ],
-
-
    add_sql_prefix => \[ 'DATETIME("me"."a_date", ? || ?)', 1, ' seconds' ],
 
    add_sql_by_part => {

--- a/t/ResultSet/Explain.t
+++ b/t/ResultSet/Explain.t
@@ -23,10 +23,7 @@ top_test basic => sub {
    }
 };
 
-run_me(SQLite => {
-   engine => 'SQLite',
-   connect_info => [ 'dbi:SQLite::memory:'],
-});
+run_me(SQLite => { engine => 'SQLite' });
 run_me(Pg     => { engine => 'Pg'     });
 run_me(mysql  => { engine => 'mysql'  });
 

--- a/t/lib/A/Role/TestConnect.pm
+++ b/t/lib/A/Role/TestConnect.pm
@@ -15,16 +15,6 @@ has storage_type => (
 
 sub connected { A::Util::connected($_[0]->engine, $_[0]->on_connect_call) }
 
-has connect_info => (
-   is => 'ro',
-   lazy => 1,
-   default => sub {
-      my $self = shift;
-
-      A::Util::connect_info($self->engine, $self->on_connect_call)
-   },
-);
-
 sub env_vars { A::Util::env(shift->engine) }
 
 has schema => (


### PR DESCRIPTION
Commit 123fa4a165834901fcef56faa111fe7fc5ce7741 has disabled the possiblity to pass in a connect_info when the creation of that property was moved from the default handler into A::Util along with the call to it in connect(), which was also moved to A::Util. When connect_info is passed to the test object it is now never used, because it does not get handed on to the A::Util::connect call that happens in the builder for schema.

It would be nicer to have the tests default to SQLite without needing an environment variable, but the current architecture in A::Util makes that tricky without changing too much. This change removes unused code and leaves the current behavior untouched.

----

I found this when looking at the coverage report, specifically the yellow file [Explain.pm](https://coveralls.io/builds/10553806/source?filename=lib%2FDBIx%2FClass%2FHelper%2FResultSet%2FExplain.pm). A further look at [travis](https://travis-ci.org/frioux/DBIx-Class-Helpers/jobs/210325734#L1254) revealed that the tests using sqlite in ::Explain never get executed.

This is my entry for the Pull Request Challenge 2017 in May.