### PR TITLE
Add helper to specify column info using types

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,9 @@ requires 'Try::Tiny';
 requires 'Safe::Isa';
 requires 'Text::Brew';
 requires 'Moo' => 2;
+requires 'Hash::Merge';
+requires 'Scalar::Util';
+requires 'Types::SQL';
 
 on test => sub {
    requires 'Test::More' => 0.94;

--- a/lib/DBIx/Class/Helper/Row/Types.pm
+++ b/lib/DBIx/Class/Helper/Row/Types.pm
@@ -1,0 +1,68 @@
+package DBIx::Class::Helper::Row::Types;
+
+# ABSTRACT: Use Types to define rows
+
+use strict;
+use warnings;
+
+use Hash::Merge qw/ merge /;
+use Scalar::Util qw/ blessed /;
+use Types::SQL::Util qw/ column_info_from_type /;
+
+sub add_columns {
+    my ( $self, @args ) = @_;
+
+    my @cols = map { $self->_apply_types_to_column_defition($_) } @args;
+
+    $self->next::method(@cols);
+}
+
+sub _apply_types_to_column_defition {
+    my ( $self, $column_info ) = @_;
+
+    return $column_info unless ref $column_info;
+
+    my $type = $column_info->{isa} or return $column_info;
+
+    my %info = column_info_from_type($type);
+
+    return merge( $column_info, \%info );
+}
+
+1;
+
+=pod
+
+=head1 SYNOPSIS
+
+In result class:
+
+  use Types::SQL -types;
+  use Types::Standard -types;
+
+ __PACKAGE__->load_components('Helper::Row::Types');
+
+ __PACKAGE__->add_column(
+    name => {
+      isa => Maybe[ Varchar[64] ],
+    },
+ );
+
+=head1 DESCRIPTION
+
+This helper allows you to specify column information by passing a
+L<Type::Tiny> object.
+
+Note that this I<does not> enforce that the data is of that type. It
+just allows you to use types as a shorthand for specifying the column
+info.
+
+A future version may add options to enforce types or coerce data.
+
+=head1 SEE ALSO
+
+L<Types::SQL::Util>
+
+L<Types::Standard>
+
+=cut

--- a/t/Row/Types.t
+++ b/t/Row/Types.t
@@ -1,0 +1,33 @@
+#!perl
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use Test::More;
+use Test::Deep;
+
+use TestSchema;
+my $schema = TestSchema->deploy_or_connect();
+$schema->prepopulate;
+
+my $rs = $schema->resultset('Typed');
+
+cmp_deeply $rs->result_source->column_info('id'),
+  {
+    data_type         => 'serial',
+    is_auto_increment => 1,
+    is_numeric        => 1,
+    isa               => isa('Type::Tiny'),
+  },
+  'id';
+
+cmp_deeply $rs->result_source->column_info('serial_number'), {
+    data_type  => 'varchar',
+    size       => 32,
+    is_numeric => 1,                   # overridden
+    isa        => isa('Type::Tiny'),
+  },
+  'serial_number';
+
+done_testing;

--- a/t/lib/TestSchema/Result/Typed.pm
+++ b/t/lib/TestSchema/Result/Typed.pm
@@ -1,0 +1,17 @@
+package TestSchema::Result::Typed;
+
+use DBIx::Class::Candy -components => [
+    qw(
+      Helper::Row::Types
+      )
+];
+
+use Types::SQL -types;
+
+table 'Typed';
+
+primary_column id => { isa => Serial };
+
+column serial_number => { isa => Varchar [32], is_numeric => 1 };
+
+1;


### PR DESCRIPTION
This adds a helper that allows the developer to specify column information by using types.