### PR TITLE
add dt_SQL_subtract to DateMethods1

### DIFF
--- a/lib/DBIx/Class/Helper/ResultSet/DateMethods1.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/DateMethods1.pm
@@ -428,6 +428,12 @@ sub dt_SQL_add {
    );
 }
 
+sub dt_SQL_subtract {
+   my ($self, $thing, $unit, $amount) = @_;
+
+   $self->dt_SQL_add($thing, $unit, -1 * $amount);
+}
+
 sub dt_SQL_pluck {
    my ($self, $thing, $part) = @_;
 
@@ -549,6 +555,10 @@ Takes two values, each an expression of L</TYPES>.
 Takes three arguments: a date conforming to L</TYPES>, a unit, and an amount.
 The idea is to add the given unit to the datetime.  See your L</IMPLEMENTATION>
 for what units are accepted.
+
+=method dt_SQL_subtract
+
+Same as L<dt_SQL_add>, but subtracts the amount.
 
 =method dt_SQL_pluck
 

--- a/lib/DBIx/Class/Helper/ResultSet/DateMethods1.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/DateMethods1.pm
@@ -380,6 +380,7 @@ sub _introspector {
                @d_args, @a_args, $diff_part_map{$unit}
             ];
          }
+      });
       $d->decorate_driver_unconnected(Oracle => datesubtract_sql => sub {
          sub {
             my ($date_sql, $unit, $amount_sql) = @_;

--- a/maint/explain-out
+++ b/maint/explain-out
@@ -15,5 +15,10 @@ if ($engine eq 'SQLite') {
    $s->deploy;
    print Dumper($s->resultset('Gnarly')->explain)
 } else {
-   print Dumper(A::Util::connect($engine, $engine)->resultset('Gnarly')->explain)
+    eval {
+        print Dumper(A::Util::connect($engine, $engine)->resultset('Gnarly')->explain)
+    };
+    if ($@) {
+        print "Problem during maint/explain-out, but probably not fatal: $@";
+    }
 }

--- a/t/ResultSet/DateMethods1/pg.t
+++ b/t/ResultSet/DateMethods1/pg.t
@@ -37,6 +37,30 @@ A::ResultSet::DateMethods1->run_tests(Pg => {
       week        => '2013-02-27 00:00:00',
    },
 
+   subtract_sql_prefix => \[ q<("me"."a_date" + ? * interval '1 second')>, -1],
+
+   subtract_sql_by_part => {
+      century     => \[ q<("a_date" + ? * interval '1 century')>,      -7  ],
+      day         => \[ q<("a_date" + ? * interval '1 day')>,          -1  ],
+      decade      => \[ q<("a_date" + ? * interval '1 decade')>,       -8  ],
+      hour        => \[ q<("a_date" + ? * interval '1 hour')>,         -2  ],
+      microsecond => \[ q<("a_date" + ? * interval '1 microseconds')>, -9 ],
+      millisecond => \[ q<("a_date" + ? * interval '1 milliseconds')>, -10 ],
+      minute      => \[ q<("a_date" + ? * interval '1 minute')>,       -3  ],
+      month       => \[ q<("a_date" + ? * interval '1 month')>,        -4  ],
+      second      => \[ q<("a_date" + ? * interval '1 second')>,       -5  ],
+      week        => \[ q<("a_date" + ? * interval '1 week')>,         -11 ],
+      year        => \[ q<("a_date" + ? * interval '1 year')>,         -6  ],
+   },
+
+   subtract_sql_by_part_result => {
+      century     => '1312-12-12 00:00:00',
+      decade      => '1932-12-12 00:00:00',
+      microsecond => '2012-12-11 23:59:59.999991',
+      millisecond => '2012-12-11 23:59:59.99',
+      week        => '2012-09-26 00:00:00',
+   },
+
    pluck_sql_prefix => \[ 'date_part(?, "me"."a_date")', 'second' ],
 
    pluck_sql_by_part => {

--- a/t/ResultSet/DateMethods1/pg.t
+++ b/t/ResultSet/DateMethods1/pg.t
@@ -37,20 +37,20 @@ A::ResultSet::DateMethods1->run_tests(Pg => {
       week        => '2013-02-27 00:00:00',
    },
 
-   subtract_sql_prefix => \[ q<("me"."a_date" + ? * interval '1 second')>, -1],
+   subtract_sql_prefix => \[ q<("me"."a_date" - ? * interval '1 second')>, 1],
 
    subtract_sql_by_part => {
-      century     => \[ q<("a_date" + ? * interval '1 century')>,      -7  ],
-      day         => \[ q<("a_date" + ? * interval '1 day')>,          -1  ],
-      decade      => \[ q<("a_date" + ? * interval '1 decade')>,       -8  ],
-      hour        => \[ q<("a_date" + ? * interval '1 hour')>,         -2  ],
-      microsecond => \[ q<("a_date" + ? * interval '1 microseconds')>, -9 ],
-      millisecond => \[ q<("a_date" + ? * interval '1 milliseconds')>, -10 ],
-      minute      => \[ q<("a_date" + ? * interval '1 minute')>,       -3  ],
-      month       => \[ q<("a_date" + ? * interval '1 month')>,        -4  ],
-      second      => \[ q<("a_date" + ? * interval '1 second')>,       -5  ],
-      week        => \[ q<("a_date" + ? * interval '1 week')>,         -11 ],
-      year        => \[ q<("a_date" + ? * interval '1 year')>,         -6  ],
+      century     => \[ q<("a_date" - ? * interval '1 century')>,      7  ],
+      day         => \[ q<("a_date" - ? * interval '1 day')>,          1  ],
+      decade      => \[ q<("a_date" - ? * interval '1 decade')>,       8  ],
+      hour        => \[ q<("a_date" - ? * interval '1 hour')>,         2  ],
+      microsecond => \[ q<("a_date" - ? * interval '1 microseconds')>, 9 ],
+      millisecond => \[ q<("a_date" - ? * interval '1 milliseconds')>, 10 ],
+      minute      => \[ q<("a_date" - ? * interval '1 minute')>,       3  ],
+      month       => \[ q<("a_date" - ? * interval '1 month')>,        4  ],
+      second      => \[ q<("a_date" - ? * interval '1 second')>,       5  ],
+      week        => \[ q<("a_date" - ? * interval '1 week')>,         11 ],
+      year        => \[ q<("a_date" - ? * interval '1 year')>,         6  ],
    },
 
    subtract_sql_by_part_result => {

--- a/t/ResultSet/DateMethods1/sqlite.t
+++ b/t/ResultSet/DateMethods1/sqlite.t
@@ -28,15 +28,15 @@ A::ResultSet::DateMethods1->run_tests(SQLite => {
       year   => \[ 'DATETIME("a_date", ? || ?)', 6, ' years' ],
    },
 
-   subtract_sql_prefix => \[ 'DATETIME("me"."a_date", ? || ?)', -1, ' seconds' ],
+   subtract_sql_prefix => \[ q{DATETIME("me"."a_date", '-' || ? || ?)}, 1, ' seconds' ],
 
    subtract_sql_by_part => {
-      day    => \[ 'DATETIME("a_date", ? || ?)', -1, ' days' ],
-      hour   => \[ 'DATETIME("a_date", ? || ?)', -2, ' hours' ],
-      minute => \[ 'DATETIME("a_date", ? || ?)', -3, ' minutes' ],
-      month  => \[ 'DATETIME("a_date", ? || ?)', -4, ' months' ],
-      second => \[ 'DATETIME("a_date", ? || ?)', -5, ' seconds' ],
-      year   => \[ 'DATETIME("a_date", ? || ?)', -6, ' years' ],
+      day    => \[ q{DATETIME("a_date", '-' || ? || ?)}, 1, ' days' ],
+      hour   => \[ q{DATETIME("a_date", '-' || ? || ?)}, 2, ' hours' ],
+      minute => \[ q{DATETIME("a_date", '-' || ? || ?)}, 3, ' minutes' ],
+      month  => \[ q{DATETIME("a_date", '-' || ? || ?)}, 4, ' months' ],
+      second => \[ q{DATETIME("a_date", '-' || ? || ?)}, 5, ' seconds' ],
+      year   => \[ q{DATETIME("a_date", '-' || ? || ?)}, 6, ' years' ],
    },
 
    pluck_sql_prefix => \[ q<STRFTIME('%S', "me"."a_date")> ],

--- a/t/ResultSet/DateMethods1/sqlite.t
+++ b/t/ResultSet/DateMethods1/sqlite.t
@@ -28,6 +28,17 @@ A::ResultSet::DateMethods1->run_tests(SQLite => {
       year   => \[ 'DATETIME("a_date", ? || ?)', 6, ' years' ],
    },
 
+   subtract_sql_prefix => \[ 'DATETIME("me"."a_date", ? || ?)', -1, ' seconds' ],
+
+   subtract_sql_by_part => {
+      day    => \[ 'DATETIME("a_date", ? || ?)', -1, ' days' ],
+      hour   => \[ 'DATETIME("a_date", ? || ?)', -2, ' hours' ],
+      minute => \[ 'DATETIME("a_date", ? || ?)', -3, ' minutes' ],
+      month  => \[ 'DATETIME("a_date", ? || ?)', -4, ' months' ],
+      second => \[ 'DATETIME("a_date", ? || ?)', -5, ' seconds' ],
+      year   => \[ 'DATETIME("a_date", ? || ?)', -6, ' years' ],
+   },
+
    pluck_sql_prefix => \[ q<STRFTIME('%S', "me"."a_date")> ],
 
    pluck_sql_by_part => {


### PR DESCRIPTION
Hi!

This pull request adds the new method `dt_SQL_subtract` to `DBIx::Class::Helper::ResultSet::DateMethods1`

It works exactly like `dt_SQL_add`, but subtracts dates (surprise!).

While one can pass negative values to `dt_SQL_add` to subtract a literal value (`$amount`), this does not work when the value is not passed as a literal value but as the name of another column where the actual value is stored. Hence this new method.

Besides the code and some docs I've added test for sqlite and postgres. As I don't have access to other database engines (and could not figure out how to connect the tests to mysql running in Docker), I did not add tests for those engines.

Please note that this work was sponsored by ctrlo.com. I have not added a note to the docs yet, but maybe it would be a nice touch to honor their support for open source software.

Greetings,
domm





