### PR TITLE
Fix results_exist for good

### DIFF
--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut.pm
@@ -159,9 +159,27 @@ calling C<< $rs->count >>.
 
  my $results_exist = $schema->resultset('Bar')->search({...})->results_exist;
 
+ # there is no easily expressable equivalent, so this is not exactly a
+ # shortcut. Nevertheless kept in this class for historical reasons
+
 Uses C<EXISTS> SQL function to check if the query would return anything.
-Possibly lighter weight than the much more common C<< foo() if $rs->count >>
+Usually much less resource intensive the more common C<< foo() if $rs->count >>
 idiom.
+
+=method results_exist_as_query
+
+ ...->search(
+    {},
+    { '+columns' => {
+       subquery_has_members => $some_correlated_rs->results_exist_as_query
+    }},
+ );
+
+ # there is no easily expressable equivalent, so this is not exactly a
+ # shortcut. Nevertheless kept in this class for historical reasons
+
+The query generator behind L</results_exist>. Can be used standalone in
+complex queries returning a boolean result within a larger query context.
 
 =method null(@columns || \@columns)
 

--- a/t/ResultSet/Shortcut/ResultsExist.t
+++ b/t/ResultSet/Shortcut/ResultsExist.t
@@ -16,4 +16,32 @@ my $rs2 = $schema->resultset( 'Foo' )->search({ id => { '<' => 0 } });
 ok( $rs->results_exist, 'check rs has some results' );
 ok(!$rs2->results_exist, 'and check that rs has no results' );
 
+is_deeply(
+   [
+      $rs->search({}, { order_by => 'id', columns => {
+
+         id => "id",
+
+         has_lesser => $rs->search(
+            { 'correlation.id' => { '<' => { -ident => "me.id" } } },
+            { alias => 'correlation' }
+         )->results_exist_as_query,
+
+         has_greater => $rs->search(
+            { 'correlation.id' => { '>' => { -ident => "me.id" } } },
+            { alias => 'correlation' }
+         )->results_exist_as_query,
+
+      }})->hri->all
+   ],
+   [
+      { id => 1, has_lesser => 0, has_greater => 1 },
+      { id => 2, has_lesser => 1, has_greater => 1 },
+      { id => 3, has_lesser => 1, has_greater => 1 },
+      { id => 4, has_lesser => 1, has_greater => 1 },
+      { id => 5, has_lesser => 1, has_greater => 0 },
+   ],
+   "Correlated-existence works",
+);
+
 done_testing;


### PR DESCRIPTION
@frioux we got to fix this man... Folks are resorting to [primitivisms like this](https://github.com/joyent/conch/blob/449e1a645f86/lib/Conch/DB/Helper/ResultSet/ResultsExist.pm#L37-L48), because the thing in Helpers doesn't work for them.

This PR takes my suggestions https://github.com/frioux/DBIx-Class-Helpers/commit/85702318c13da517d0c9d6b997ff346fdc47abba#commitcomment-25738859 and https://github.com/frioux/DBIx-Class-Helpers/commit/85702318c13da517d0c9d6b997ff346fdc47abba#commitcomment-26140541 and combines them with some docs.

This is what I've been using at work for close to 3 years now, it should work across all DBs unmodified.

Obsoletes/addresses:
- https://github.com/frioux/DBIx-Class-Helpers/issues/54
- https://github.com/frioux/DBIx-Class-Helpers/commit/fd4024322fb7601352f2caf1ab6c5873f6ea6263
- https://github.com/frioux/DBIx-Class-Helpers/tree/fix-results-exist


Cheers