### PR TITLE
actually fix results_exist for pg

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -16,6 +16,16 @@ $ maint/dockerprove -lr t
 You can set DBIITEST_STARTUP to 10 or 15 to wait longer for the databases to be
 ready to test against.  Default is 5s.
 
+## Writing Tests
+
+By default, tests will only be run against SQLite. To write tests
+that will run on other DBs, use Test::Roo, and compose in the role
+A::Role::TestConnect. This will lazily connect (and deploy) the
+schema once the schema method is called. To run tests only if
+connected, check the connected method.
+
+For the simplest example of this, take a look at t/ResultSet/Explain.t.
+
 ## Releasing
 
 ```

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
@@ -14,7 +14,7 @@ sub results_exist_as_query {
    } )->as_query;
 
 
-   $$reified->[0] = "( SELECT EXISTS $$reified->[0] ) as forty_two";
+   $$reified->[0] = "( SELECT EXISTS $$reified->[0] )";
 
 
    $reified;
@@ -23,6 +23,9 @@ sub results_exist_as_query {
 
 sub results_exist {
    my $self = shift;
+
+   my $query = $self->results_exist_as_query;
+   $$query->[0] .= 'as _existence_subq';
 
    my( undef, $sth ) = $self->result_source
                              ->schema

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
@@ -25,7 +25,7 @@ sub results_exist {
    my $self = shift;
 
    my $query = $self->results_exist_as_query;
-   $$query->[0] .= 'as _existence_subq';
+   $$query->[0] .= 'AS _existence_subq';
 
    my( undef, $sth ) = $self->result_source
                              ->schema

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
@@ -31,7 +31,7 @@ sub results_exist {
                              ->schema
                               ->storage
                                ->_select(
-                                  $self->results_exist_as_query,
+                                 $query,
                                   \'*',
                                   {},
                                   {},

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
@@ -25,7 +25,7 @@ sub results_exist {
    my $self = shift;
 
    my $query = $self->results_exist_as_query;
-   $$query->[0] .= 'AS _existence_subq';
+   $$query->[0] .= ' AS _existence_subq';
 
    my( undef, $sth ) = $self->result_source
                              ->schema

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
@@ -14,7 +14,7 @@ sub results_exist_as_query {
    } )->as_query;
 
 
-   $$reified->[0] = "( SELECT EXISTS $$reified->[0] )";
+   $$reified->[0] = "( SELECT EXISTS $$reified->[0] ) as forty_two";
 
 
    $reified;

--- a/t/ResultSet/Explain.t
+++ b/t/ResultSet/Explain.t
@@ -16,7 +16,7 @@ top_test basic => sub {
    my $rs = $self->rs;
    SKIP: {
       skip 'cannot test without a connection', 1 unless $self->connected;
-      $ran++;
+      $ran++ if $self->engine eq 'SQLite';
 
       my $s;
       my $e = exception { $s = $rs->explain };
@@ -32,5 +32,5 @@ run_me(SQLite => {
 run_me(Pg     => { engine => 'Pg'     });
 run_me(mysql  => { engine => 'mysql'  });
 
-ok $ran, 'tests were acutally run';
+ok $ran, 'tests were run against default SQLite';
 done_testing;

--- a/t/ResultSet/Explain.t
+++ b/t/ResultSet/Explain.t
@@ -10,11 +10,13 @@ with 'A::Role::TestConnect';
 
 sub rs { shift->schema->resultset('Gnarly') }
 
+my $ran;
 top_test basic => sub {
    my $self = shift;
    my $rs = $self->rs;
    SKIP: {
       skip 'cannot test without a connection', 1 unless $self->connected;
+      $ran++;
 
       my $s;
       my $e = exception { $s = $rs->explain };
@@ -30,4 +32,5 @@ run_me(SQLite => {
 run_me(Pg     => { engine => 'Pg'     });
 run_me(mysql  => { engine => 'mysql'  });
 
+ok $ran, 'tests were acutally run';
 done_testing;

--- a/t/ResultSet/Shortcut/ResultsExist.t
+++ b/t/ResultSet/Shortcut/ResultsExist.t
@@ -3,45 +3,65 @@
 use strict;
 use warnings;
 
+use Test::Roo;
+
 use lib 't/lib';
-use Test::More;
 
-use TestSchema;
-my $schema = TestSchema->deploy_or_connect();
-$schema->prepopulate;
+with 'A::Role::TestConnect';
 
-my $rs = $schema->resultset( 'Foo' )->search({ id => { '>' => 0 } });
-my $rs2 = $schema->resultset( 'Foo' )->search({ id => { '<' => 0 } });
+my $ran = 0;
 
-ok( $rs->results_exist, 'check rs has some results' );
-ok(!$rs2->results_exist, 'and check that rs has no results' );
+top_test 'basic functionality' => sub {
+  my $self = shift;
+  my $schema = $self->schema;
+  SKIP: {
+    skip 'cannot test without a connection', 1 unless $self->connected;
 
-is_deeply(
-   [
-      $rs->search({}, { order_by => 'id', columns => {
+    $ran++;
+    $schema->prepopulate;
 
-         id => "id",
+    my $rs = $schema->resultset( 'Foo' )->search({ id => { '>' => 0 } });
+    my $rs2 = $schema->resultset( 'Foo' )->search({ id => { '<' => 0 } });
 
-         has_lesser => $rs->search(
-            { 'correlation.id' => { '<' => { -ident => "me.id" } } },
-            { alias => 'correlation' }
-         )->results_exist_as_query,
+    ok( $rs->results_exist, 'check rs has some results' );
+    ok(!$rs2->results_exist, 'and check that rs has no results' );
 
-         has_greater => $rs->search(
-            { 'correlation.id' => { '>' => { -ident => "me.id" } } },
-            { alias => 'correlation' }
-         )->results_exist_as_query,
+    is_deeply(
+       [
+          $rs->search({}, { order_by => 'id', columns => {
 
-      }})->hri->all
-   ],
-   [
-      { id => 1, has_lesser => 0, has_greater => 1 },
-      { id => 2, has_lesser => 1, has_greater => 1 },
-      { id => 3, has_lesser => 1, has_greater => 1 },
-      { id => 4, has_lesser => 1, has_greater => 1 },
-      { id => 5, has_lesser => 1, has_greater => 0 },
-   ],
-   "Correlated-existence works",
-);
+             id => "id",
 
+             has_lesser => $rs->search(
+                { 'correlation.id' => { '<' => { -ident => "me.id" } } },
+                { alias => 'correlation' }
+             )->results_exist_as_query,
+
+             has_greater => $rs->search(
+                { 'correlation.id' => { '>' => { -ident => "me.id" } } },
+                { alias => 'correlation' }
+             )->results_exist_as_query,
+
+          }})->hri->all
+       ],
+       [
+          { id => 1, has_lesser => 0, has_greater => 1 },
+          { id => 2, has_lesser => 1, has_greater => 1 },
+          { id => 3, has_lesser => 1, has_greater => 1 },
+          { id => 4, has_lesser => 1, has_greater => 1 },
+          { id => 5, has_lesser => 1, has_greater => 0 },
+       ],
+       "Correlated-existence works",
+    );
+  }
+};
+
+run_me(SQLite => {
+   engine => 'SQLite',
+   connect_info => [ 'dbi:SQLite::memory:'],
+});
+run_me(Pg     => { engine => 'Pg'     });
+run_me(mysql  => { engine => 'mysql'  });
+
+ok $ran, 'tests were acutally run';
 done_testing;

--- a/t/ResultSet/Shortcut/ResultsExist.t
+++ b/t/ResultSet/Shortcut/ResultsExist.t
@@ -17,7 +17,7 @@ top_test 'basic functionality' => sub {
   SKIP: {
     skip 'cannot test without a connection', 1 unless $self->connected;
 
-    $ran++;
+    $ran++ if $self->engine eq 'SQLite';
     $schema->prepopulate;
 
     my $rs = $schema->resultset( 'Foo' )->search({ id => { '>' => 0 } });
@@ -63,5 +63,5 @@ run_me(SQLite => {
 run_me(Pg     => { engine => 'Pg'     });
 run_me(mysql  => { engine => 'mysql'  });
 
-ok $ran, 'tests were acutally run';
+ok $ran, 'tests were run against default SQLite';
 done_testing;

--- a/t/lib/A/Util.pm
+++ b/t/lib/A/Util.pm
@@ -38,6 +38,7 @@ sub connect_info {
 }
 
 sub connected {
+   return 1 if $_[0] eq 'SQLite';
    !!@{connect_info(@_)}
 }
 

--- a/t/lib/ParentSchema/Result/Bar.pm
+++ b/t/lib/ParentSchema/Result/Bar.pm
@@ -16,6 +16,7 @@ column foo_id => {
 
 column test_flag => {
    keep_storage_value => 1,
+   data_type => 'integer',
    is_nullable => 1,
 };
 

--- a/t/lib/ParentSchema/Result/Foo.pm
+++ b/t/lib/ParentSchema/Result/Foo.pm
@@ -15,7 +15,8 @@ column bar_id => {
 
 primary_key 'id';
 
-belongs_to bar =>  'ParentSchema::Result::Bar', 'bar_id';
+belongs_to bar =>  'ParentSchema::Result::Bar', 'bar_id',
+{ is_foreign_key_constraint => 0 };
 has_many   bars => 'ParentSchema::Result::Bar', 'foo_id';
 
 1;

--- a/t/lib/ParentSchema/Result/Foo.pm
+++ b/t/lib/ParentSchema/Result/Foo.pm
@@ -15,8 +15,7 @@ column bar_id => {
 
 primary_key 'id';
 
-belongs_to bar =>  'ParentSchema::Result::Bar', 'bar_id',
-{ is_foreign_key_constraint => 0 };
+belongs_to bar =>  'ParentSchema::Result::Bar', 'bar_id';
 has_many   bars => 'ParentSchema::Result::Bar', 'foo_id';
 
 1;

--- a/t/lib/TestSchema.pm
+++ b/t/lib/TestSchema.pm
@@ -57,6 +57,15 @@ sub generate_ddl {
           ($_ ne 'SQLite'
             ? (
                 add_drop_table => 1,
+                filters => [
+                  sub { 
+                    #remove circular dependency. Not used for
+                    #non-sqlite tests
+                    my $foo = shift->get_table('Foo');
+                    my @constraints = map { $_->name } $foo->get_constraints;
+                    $foo->drop_constraint($_) for grep { /bar/ } @constraints;
+                  }
+                ]
               )
             : ( add_drop_table => 0 )
          )

--- a/t/lib/TestSchema.pm
+++ b/t/lib/TestSchema.pm
@@ -57,7 +57,7 @@ sub generate_ddl {
           ($_ ne 'SQLite'
             ? (
                 add_drop_table => 1,
-                parser_args => { sources => ['HasDateOps', 'Gnarly'] })
+              )
             : ( add_drop_table => 0 )
          )
       },


### PR DESCRIPTION
The current fix for results exists STILL doesn't work on PG, because it doesn't alias the inner subquery (which is necessary at least on PG10, so I have this problem).

This just adds an alias to the table so that pg won't complain.