### PR TITLE
Add support for query condition to Helper::ResultSet::Shortcut::ResultsExist

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
  - fix remove_columns shortcut to add the 'remove_columns' attribute
    in case it is missing (Karen Etheridge, #101)
+ - Add support for query condition to results_exist() and
+   results_exist_as_query() in Helper::ResultSet::Shortcut::ResultsExist
+   (Daniel Böhmer, GH#102)
 
 2.035000  2020-02-21 08:38:42-08:00 America/Los_Angeles
  - add remove_columns shortcut (Karen Etheridge, GH#100)

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut.pm
@@ -163,7 +163,7 @@ calling C<< $rs->count >>.
  # equivalent to...
  $foo_rs->search(undef, { prefetch => 'bar' });
 
-=method results_exist
+=method results_exist($cond?)
 
  my $results_exist = $schema->resultset('Bar')->search({...})->results_exist;
 
@@ -174,7 +174,9 @@ Uses C<EXISTS> SQL function to check if the query would return anything.
 Usually much less resource intensive the more common C<< foo() if $rs->count >>
 idiom.
 
-=method results_exist_as_query
+The optional C<$cond> argument can be used like in C<search()>.
+
+=method results_exist_as_query($cond?)
 
  ...->search(
     {},

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
@@ -6,10 +6,10 @@ use warnings;
 use parent 'DBIx::Class::ResultSet';
 
 sub results_exist_as_query {
-   my $self = shift;
+   my ($self, $cond) = @_;
 
 
-   my $reified = $self->search_rs( {}, {
+   my $reified = $self->search_rs( $cond, {
       columns => { _results_existence_check => \ '42' }
    } )->as_query;
 
@@ -22,9 +22,9 @@ sub results_exist_as_query {
 
 
 sub results_exist {
-   my $self = shift;
+   my ($self, $cond) = @_;
 
-   my $query = $self->results_exist_as_query;
+   my $query = $self->results_exist_as_query($cond);
    $$query->[0] .= ' AS _existence_subq';
 
    my( undef, $sth ) = $self->result_source

--- a/t/ResultSet/Shortcut/ResultsExist.t
+++ b/t/ResultSet/Shortcut/ResultsExist.t
@@ -20,11 +20,15 @@ top_test 'basic functionality' => sub {
     $ran++ if $self->engine eq 'SQLite';
     $schema->prepopulate;
 
-    my $rs = $schema->resultset( 'Foo' )->search({ id => { '>' => 0 } });
-    my $rs2 = $schema->resultset( 'Foo' )->search({ id => { '<' => 0 } });
+    my $rs = $schema->resultset( 'Foo' );
+    my $rs_true  = $schema->resultset( 'Foo' )->search({ id => { '>' => 0 } });
+    my $rs_false = $schema->resultset( 'Foo' )->search({ id => { '<' => 0 } });
 
-    ok( $rs->results_exist, 'check rs has some results' );
-    ok(!$rs2->results_exist, 'and check that rs has no results' );
+    ok( $rs_true ->results_exist, 'check rs has some results' );
+    ok(!$rs_false->results_exist, 'and check that rs has no results' );
+
+    ok( $rs->results_exist({ id => { '>' => 0 } }), 'check that query has some results' );
+    ok(!$rs->results_exist({ id => { '<' => 0 } }), 'and check that query has no results' );
 
     is_deeply(
        [


### PR DESCRIPTION
I love DBIx-Class-Helpers and very often use some of its components! Just recently I've found that is also provides an `EXISTS` helper. Yay, thanks for your great work on this dist! :+1: 

I suggest passing the 1st argument to `results_exist()` along to have a similar usage like `search()`.

In my project Coocook I added my own custom `exists()` method and I'd like to migrate to your code. But I often pass a query to my `exists()` like [here](https://github.com/dboehmer/coocook/blob/e6d2617566669547a78b4355367df9e7bbb5d9df/lib/Coocook/Schema/Result/User.pm#L128).

For reference: My method is implemented in [`Coocook::Schema::ResultSet`](https://github.com/dboehmer/coocook/blob/e6d2617566669547a78b4355367df9e7bbb5d9df/lib/Coocook/Schema/ResultSet.pm#L46)

Beware:
* Because I had no Docker at hand I checked the changes only with `prove -l t/ResultSet/Shortcut/ResultsExist.t`
* This is my first PR to DBIx-Class-Helpers. I tried to align to your code style and hope more tricks from my code can be included in upstream.