### PR TITLE
Reduce inheritance, fix #91

### DIFF
--- a/lib/DBIx/Class/Helper/ResultSet/AutoRemoveColumns.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/AutoRemoveColumns.pm
@@ -5,7 +5,7 @@ package DBIx::Class::Helper::ResultSet::AutoRemoveColumns;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Helper::ResultSet::RemoveColumns', 'DBIx::Class::ResultSet';
+use parent 'DBIx::Class::Helper::ResultSet::RemoveColumns','DBIx::Class::AccessorGroup';
 
 __PACKAGE__->mk_group_accessors(inherited => '_fetchable_columns');
 

--- a/lib/DBIx/Class/Helper/ResultSet/Bare.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Bare.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::Bare;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub bare { shift->result_source->resultset }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/DateMethods1.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/DateMethods1.pm
@@ -2,8 +2,6 @@ package DBIx::Class::Helper::ResultSet::DateMethods1;
 
 # ABSTRACT: Work with dates in your RDBMS nicely
 
-use parent 'DBIx::Class::ResultSet';
-
 use strict;
 use warnings;
 

--- a/lib/DBIx/Class/Helper/ResultSet/Errors.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Errors.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::Errors;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 my $std_err = qq{Can't locate object method "%s" via package "%s" } .
               qq{at %s line %d.\n};
 

--- a/lib/DBIx/Class/Helper/ResultSet/Explain.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Explain.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::Explain;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 use DBIx::Introspector;
 
 sub _introspector {

--- a/lib/DBIx/Class/Helper/ResultSet/IgnoreWantarray.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/IgnoreWantarray.pm
@@ -5,9 +5,7 @@ package DBIx::Class::Helper::ResultSet::IgnoreWantarray;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
-sub search :DBIC_method_is_indirect_sugar{
+sub search {
    $_[0]->throw_exception ('->search is *not* a mutator, calling it in void context makes no sense')
       if !defined wantarray && (caller)[0] !~ /^\QDBIx::Class::/;
 

--- a/lib/DBIx/Class/Helper/ResultSet/Me.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Me.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::Me;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub me { join('.', shift->current_source_alias, shift || q{})  }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/NoColumns.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/NoColumns.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::NoColumns;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub no_columns { $_[0]->search(undef, { columns => [] }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::OneRow;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub one_row { shift->search(undef, { rows => 1})->next }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Random.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Random.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::Random;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 use Module::Runtime 'use_module';
 use Try::Tiny;
 

--- a/lib/DBIx/Class/Helper/ResultSet/RemoveColumns.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/RemoveColumns.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::RemoveColumns;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub _resolved_attrs {
    my $self = $_[0];
 

--- a/lib/DBIx/Class/Helper/ResultSet/ResultClassDWIM.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/ResultClassDWIM.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::ResultClassDWIM;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub result_class {
    my ($self, $result_class) = @_;
 

--- a/lib/DBIx/Class/Helper/ResultSet/SearchOr.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/SearchOr.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::SearchOr;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 use List::Util 'first';
 use Carp::Clan;
 use namespace::clean;

--- a/lib/DBIx/Class/Helper/ResultSet/SetOperations.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/SetOperations.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::ResultSet::SetOperations;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 # cribbed from perlfaq4
 sub _compare_arrays {
    my ($self, $first, $second) = @_;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/AddColumns.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/AddColumns.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::AddColumns;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub add_columns { shift->search(undef, { '+columns' => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/Columns.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/Columns.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::Columns;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub columns { shift->search(undef, { columns => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/Distinct.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/Distinct.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::Distinct;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub distinct { $_[0]->search(undef, { distinct => defined $_[1] ? $_[1] : 1 }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/GroupBy.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/GroupBy.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::GroupBy;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub group_by { shift->search(undef, { group_by => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/HRI.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/HRI.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::HRI;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub hri {
    shift->search(undef, {
       result_class => 'DBIx::Class::ResultClass::HashRefInflator' })

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/HasRows.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/HasRows.pm
@@ -3,7 +3,7 @@ package DBIx::Class::Helper::ResultSet::Shortcut::HasRows;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Helper::ResultSet::Shortcut::Rows', 'DBIx::Class::ResultSet';
+use parent 'DBIx::Class::Helper::ResultSet::Shortcut::Rows';
 
 sub has_rows { !! shift->rows(1)->next }
 

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/Limit.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/Limit.pm
@@ -3,7 +3,7 @@ package DBIx::Class::Helper::ResultSet::Shortcut::Limit;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Helper::ResultSet::Shortcut::Rows', 'DBIx::Class::ResultSet';
+use parent 'DBIx::Class::Helper::ResultSet::Shortcut::Rows';
 
 sub limit { return shift->rows(@_) }
 

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/LimitedPage.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/LimitedPage.pm
@@ -6,7 +6,6 @@ use warnings;
 use parent qw(
   DBIx::Class::Helper::ResultSet::Shortcut::Rows
   DBIx::Class::Helper::ResultSet::Shortcut::Page
-  DBIx::Class::ResultSet
 );
 
 sub limited_page {

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/OrderBy.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/OrderBy.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::OrderBy;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub order_by { shift->search(undef, { order_by => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/OrderByMagic.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/OrderByMagic.pm
@@ -3,7 +3,7 @@ package DBIx::Class::Helper::ResultSet::Shortcut::OrderByMagic;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Helper::ResultSet::Shortcut::OrderBy', 'DBIx::Class::ResultSet';
+use parent 'DBIx::Class::Helper::ResultSet::Shortcut::OrderBy';
 
 sub order_by {
     my ($self, @order) = @_;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/Page.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/Page.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::Page;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub page { shift->search(undef, { page => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/Prefetch.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/Prefetch.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::Prefetch;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub prefetch { return shift->search(undef, { prefetch => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/RemoveColumns.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/RemoveColumns.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::RemoveColumns;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub remove_columns { shift->search(undef, { remove_columns => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/ResultsExist.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::ResultsExist;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub results_exist_as_query {
    my $self = shift;
 

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/Rows.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/Rows.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::Rows;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 sub rows { shift->search(undef, { rows => shift }) }
 
 1;

--- a/lib/DBIx/Class/Helper/ResultSet/Shortcut/Search/Base.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/Shortcut/Search/Base.pm
@@ -3,8 +3,6 @@ package DBIx::Class::Helper::ResultSet::Shortcut::Search::Base;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::ResultSet';
-
 #--------------------------------------------------------------------------#
 # _helper_unwrap_columns(@columns)
 #--------------------------------------------------------------------------#

--- a/lib/DBIx/Class/Helper/ResultSet/VirtualView.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/VirtualView.pm
@@ -6,8 +6,6 @@ use strict;
 use warnings;
 use vars qw($VERSION);
 
-use parent 'DBIx::Class::ResultSet';
-
 sub as_virtual_view {
    my $self = shift;
 

--- a/lib/DBIx/Class/Helper/Row/CleanResultSet.pm
+++ b/lib/DBIx/Class/Helper/Row/CleanResultSet.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::Row::CleanResultSet;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
-
 sub clean_rs { return shift->result_source->resultset }
 
 1;

--- a/lib/DBIx/Class/Helper/Row/JoinTable.pm
+++ b/lib/DBIx/Class/Helper/Row/JoinTable.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::Row::JoinTable;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
-
 use DBIx::Class::Helpers::Util 'get_namespace_parts';
 use Lingua::EN::Inflect ();
 use DBIx::Class::Candy::Exports;

--- a/lib/DBIx/Class/Helper/Row/NumifyGet.pm
+++ b/lib/DBIx/Class/Helper/Row/NumifyGet.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::Row::NumifyGet;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
-
 use Try::Tiny;
 
 sub get_column {

--- a/lib/DBIx/Class/Helper/Row/OnColumnChange.pm
+++ b/lib/DBIx/Class/Helper/Row/OnColumnChange.pm
@@ -5,7 +5,7 @@ package DBIx::Class::Helper::Row::OnColumnChange;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Helper::Row::StorageValues', 'DBIx::Class::Row';
+use parent 'DBIx::Class::Helper::Row::StorageValues';
 
 use List::Util 'first';
 use DBIx::Class::Candy::Exports;

--- a/lib/DBIx/Class/Helper/Row/OnColumnMissing.pm
+++ b/lib/DBIx/Class/Helper/Row/OnColumnMissing.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::Row::OnColumnMissing;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
-
 sub on_column_missing { 'warn' }
 
 sub on_column_missing_die  {  die "Column $_[1] has not been loaded" }

--- a/lib/DBIx/Class/Helper/Row/ProxyResultSetMethod.pm
+++ b/lib/DBIx/Class/Helper/Row/ProxyResultSetMethod.pm
@@ -5,7 +5,7 @@ package DBIx::Class::Helper::Row::ProxyResultSetMethod;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Helper::Row::SelfResultSet', 'DBIx::Class::Row';
+use parent 'DBIx::Class::Helper::Row::SelfResultSet','DBIx::Class::AccessorGroup';
 
 use Sub::Name ();
 

--- a/lib/DBIx/Class/Helper/Row/ProxyResultSetUpdate.pm
+++ b/lib/DBIx/Class/Helper/Row/ProxyResultSetUpdate.pm
@@ -5,7 +5,7 @@ package DBIx::Class::Helper::Row::ProxyResultSetUpdate;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Helper::Row::SelfResultSet', 'DBIx::Class::Row';
+use parent 'DBIx::Class::Helper::Row::SelfResultSet';
 
 sub update {
   my ($self, $upd) = @_;

--- a/lib/DBIx/Class/Helper/Row/RelationshipDWIM.pm
+++ b/lib/DBIx/Class/Helper/Row/RelationshipDWIM.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::Row::RelationshipDWIM;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
-
 sub default_result_namespace {
    die 'you forgot to set your default_result_namespace'
 }

--- a/lib/DBIx/Class/Helper/Row/SelfResultSet.pm
+++ b/lib/DBIx/Class/Helper/Row/SelfResultSet.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::Row::SelfResultSet;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
-
 sub self_rs {
    my ($self) = @_;
 

--- a/lib/DBIx/Class/Helper/Row/StorageValues.pm
+++ b/lib/DBIx/Class/Helper/Row/StorageValues.pm
@@ -5,7 +5,7 @@ package DBIx::Class::Helper::Row::StorageValues;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
+use parent 'DBIx::Class::AccessorGroup';
 
 __PACKAGE__->mk_group_accessors(inherited => '_storage_value_columns');
 __PACKAGE__->mk_group_accessors(inherited => '_storage_values');

--- a/lib/DBIx/Class/Helper/Row/SubClass.pm
+++ b/lib/DBIx/Class/Helper/Row/SubClass.pm
@@ -5,8 +5,6 @@ package DBIx::Class::Helper::Row::SubClass;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
-
 use DBIx::Class::Helpers::Util qw{get_namespace_parts assert_similar_namespaces};
 use DBIx::Class::Candy::Exports;
 

--- a/lib/DBIx/Class/Helper/Row/ToJSON.pm
+++ b/lib/DBIx/Class/Helper/Row/ToJSON.pm
@@ -5,7 +5,7 @@ package DBIx::Class::Helper::Row::ToJSON;
 use strict;
 use warnings;
 
-use parent 'DBIx::Class::Row';
+use parent 'DBIx::Class::AccessorGroup';
 
 __PACKAGE__->mk_group_accessors(inherited => '_serializable_columns');
 __PACKAGE__->mk_group_accessors(inherited => '_unserializable_data_types');

--- a/t/component-order.t
+++ b/t/component-order.t
@@ -1,0 +1,57 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+{
+    package MyBase1;
+    use strict;
+    use warnings;
+    use parent 'DBIx::Class::Core';
+    __PACKAGE__->load_components(
+        'InflateColumn::DateTime',
+        'Helper::Row::SelfResultSet',
+    );
+}
+
+{
+    package MyBase2;
+    use strict;
+    use warnings;
+    use parent 'DBIx::Class::Core';
+    __PACKAGE__->load_components(
+        'Helper::Row::SelfResultSet',
+        'InflateColumn::DateTime',
+    );
+}
+
+BEGIN {
+    $INC{'MyBase1.pm'} = __FILE__;
+    $INC{'MyBase2.pm'} = __FILE__;
+}
+
+{
+    package MyRow1;
+    use strict;
+    use warnings;
+    use parent 'MyBase1';
+}
+
+{
+    package MyRow2;
+    use strict;
+    use warnings;
+    use parent 'MyBase2';
+}
+
+for my $class (qw(MyBase1 MyBase2 MyRow1 MyRow2)) {
+    is(
+        $class->can('register_column'),
+        DBIx::Class::InflateColumn::DateTime->can('register_column'),
+        "$class should register inflated columns",
+    );
+}
+
+done_testing;


### PR DESCRIPTION
I have removed most `use parent`, and replaced the necessary ones with the smallest needed class.

I've also added a test showing the problem reported in issue #91. I think the root of the problem is that derived classes that don't call `load_components` don't get the C3 mro.

All tests still pass on my machine.