### PR TITLE
Add support for query condition to one_row() in Helper::ResultSet::OneRow

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
  - fix example code for sub _should_column_fetch in
    ::ResultSet::AutoRemoveColumns (closes GH#106)
+ - Add support for query condition to one_row() in
+   Helper::ResultSet::OneRow (Daniel Böhmer, GH#109)
 
 2.036000  2020-03-28 14:16:39-07:00 America/Los_Angeles
  - fix remove_columns shortcut to add the 'remove_columns' attribute

--- a/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
@@ -63,4 +63,4 @@ object. In case no rows match, C<undef> is returned as normal.
 
 Thanks to Aran Clary Deltac (BLUEFEET) for initially writing this module, and
 thanks to L<ZipRecruiter|https://www.ziprecruiter.com> for sponsoring that
-initial developmentl
+initial development.

--- a/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
+++ b/lib/DBIx/Class/Helper/ResultSet/OneRow.pm
@@ -7,7 +7,7 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
-sub one_row { shift->search(undef, { rows => 1})->next }
+sub one_row { shift->search(shift, { rows => 1})->next }
 
 1;
 
@@ -54,10 +54,12 @@ default.
 
 =head1 METHODS
 
-=head2 one_row
+=head2 one_row($cond?)
 
 Limits the ResultSet to a single row, and then returns the matching result
 object. In case no rows match, C<undef> is returned as normal.
+
+The optional C<$cond> argument can be used like in C<search()>.
 
 =head1 THANKS
 

--- a/t/ResultSet/OneRow.t
+++ b/t/ResultSet/OneRow.t
@@ -14,5 +14,11 @@ my $rs = $schema->resultset('Gnarly');
 
 isa_ok($rs->one_row, 'TestSchema::Result::Gnarly', '->one_row');
 
+ok(!defined $rs->search({name => 'zzz'})->one_row, '->one_row for empty resultset');
+
+is(my $row = $rs->one_row({name => 'frioux'})->name, 'frioux', '->one_row with condition');
+
+ok(!$rs->one_row({name => 'zzz'}), '->one_row with condition that matches zero rows');
+
 done_testing;
 


### PR DESCRIPTION
Basically the same like #102.

Also fixes a typo. I didn’t bother to open multiple PRs for that.